### PR TITLE
Fix string problem in injectSchemas()

### DIFF
--- a/src/core/injectSchemas.test.ts
+++ b/src/core/injectSchemas.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "@jest/globals";
+import injectSchemas from "./injectSchemas";
+
+describe("injectSchemas", () => {
+  it("should inject the schema name into the code", () => {
+    const code = `
+      const { GET } = defineRoute({
+        requestBody: User,
+      });
+    `;
+    const output = injectSchemas(code, "User");
+    expect(output).toBe(`
+      const { GET } = defineRoute({
+        requestBody: "User",
+      });
+    `);
+  });
+
+  it("should handle zod helper functions", () => {
+    const code = `
+      const { GET } = defineRoute({
+        requestBody: User.pick({ id: true }),
+      });
+    `;
+    const output = injectSchemas(code, "User");
+    expect(output).toBe(`
+      const { GET } = defineRoute({
+        requestBody: global.schemas["User"].pick({ id: true }),
+      });
+    `);
+  });
+
+  it("should leave the strings alone", () => {
+    const code = `
+      const { GET } = defineRoute({
+        requestBody: User.pick({ id: true }),
+        responses: {
+          200: { description: "User. found", content: User },
+          400: { description: 'Bad Request' },
+          404: { description: \`User not found\` }
+        },
+      });
+    `;
+    const output = injectSchemas(code, "User");
+    expect(output).toBe(`
+      const { GET } = defineRoute({
+        requestBody: global.schemas["User"].pick({ id: true }),
+        responses: {
+          200: { description: "User. found", content: "User" },
+          400: { description: 'Bad Request' },
+          404: { description: \`User not found\` }
+        },
+      });
+    `);
+  });
+});

--- a/src/core/injectSchemas.ts
+++ b/src/core/injectSchemas.ts
@@ -1,0 +1,5 @@
+export default function injectSchemas(code: string, refName: string) {
+  return code
+    .replace(new RegExp(`\\b${refName}\\.`, "g"), `global.schemas[${refName}].`)
+    .replace(new RegExp(`\\b${refName}\\b`, "g"), `"${refName}"`);
+}

--- a/src/core/injectSchemas.ts
+++ b/src/core/injectSchemas.ts
@@ -1,5 +1,33 @@
+function generateRandomString(length: number) {
+  return [...Array(length)].map(() => Math.random().toString(36)[2]).join("");
+}
+
+function preserveStrings(code: string) {
+  let replacements = {} as Record<string, string>;
+
+  const output = code.replace(/(['"`])([^'`"]+)\1/g, replacedString => {
+    const replacementId = generateRandomString(32);
+    replacements = {
+      ...replacements,
+      [replacementId]: replacedString,
+    };
+    return `<@~${replacementId}~@>`;
+  });
+  return { output, replacements };
+}
+
+function restoreStrings(code: string, replacements: Record<string, string>) {
+  return code.replace(/<@~(.*?)~@>/g, (_, replacementId) => {
+    return replacements[replacementId];
+  });
+}
+
 export default function injectSchemas(code: string, refName: string) {
-  return code
+  const { output: preservedCode, replacements } = preserveStrings(code);
+
+  const preservedCodeWithSchemasInjected = preservedCode
     .replace(new RegExp(`\\b${refName}\\.`, "g"), `global.schemas[${refName}].`)
     .replace(new RegExp(`\\b${refName}\\b`, "g"), `"${refName}"`);
+
+  return restoreStrings(preservedCodeWithSchemasInjected, replacements);
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new function for injecting schema names into code snippets.
	- Added functionality to preserve and restore string literals during schema injection.
- **Tests**
	- Implemented a comprehensive suite of unit tests for the new schema injection functionality, covering various scenarios.
- **Refactor**
	- Streamlined the integration of the schema injection function within the routing logic, improving overall code clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->