### PR TITLE
Imported queryParams bug

### DIFF
--- a/src/core/injectSchemas.test.ts
+++ b/src/core/injectSchemas.test.ts
@@ -53,4 +53,32 @@ describe("injectSchemas", () => {
       });
     `);
   });
+
+  it("should wrap the imported queryParams schema name with global.schemas", () => {
+    const code = `
+      const { GET } = defineRoute({
+        queryParams: User,
+      });
+    `;
+    const output = injectSchemas(code, "User");
+    expect(output).toBe(`
+      const { GET } = defineRoute({
+        queryParams: global.schemas["User"],
+      });
+    `);
+  });
+
+  it("should wrap the imported pathParams schema name with global.schemas", () => {
+    const code = `
+      const { GET } = defineRoute({
+        pathParams: User,
+      });
+    `;
+    const output = injectSchemas(code, "User");
+    expect(output).toBe(`
+      const { GET } = defineRoute({
+        pathParams: global.schemas["User"],
+      });
+    `);
+  });
 });

--- a/src/core/injectSchemas.ts
+++ b/src/core/injectSchemas.ts
@@ -5,7 +5,8 @@ export default function injectSchemas(code: string, refName: string) {
 
   const preservedCodeWithSchemasInjected = preservedCode
     .replace(new RegExp(`\\b${refName}\\.`, "g"), `global.schemas[${refName}].`)
-    .replace(new RegExp(`\\b${refName}\\b`, "g"), `"${refName}"`);
+    .replace(new RegExp(`\\b${refName}\\b`, "g"), `"${refName}"`)
+    .replace(new RegExp(`queryParams:\\s*['"\`]${refName}['"\`]`, "g"), `queryParams: global.schemas["${refName}"]`);
 
   return restoreStrings(preservedCodeWithSchemasInjected, replacements);
 }

--- a/src/core/injectSchemas.ts
+++ b/src/core/injectSchemas.ts
@@ -6,7 +6,8 @@ export default function injectSchemas(code: string, refName: string) {
   const preservedCodeWithSchemasInjected = preservedCode
     .replace(new RegExp(`\\b${refName}\\.`, "g"), `global.schemas[${refName}].`)
     .replace(new RegExp(`\\b${refName}\\b`, "g"), `"${refName}"`)
-    .replace(new RegExp(`queryParams:\\s*['"\`]${refName}['"\`]`, "g"), `queryParams: global.schemas["${refName}"]`);
+    .replace(new RegExp(`queryParams:\\s*['"\`]${refName}['"\`]`, "g"), `queryParams: global.schemas["${refName}"]`)
+    .replace(new RegExp(`pathParams:\\s*['"\`]${refName}['"\`]`, "g"), `pathParams: global.schemas["${refName}"]`);
 
   return restoreStrings(preservedCodeWithSchemasInjected, replacements);
 }

--- a/src/core/isDocumentedRoute.test.ts
+++ b/src/core/isDocumentedRoute.test.ts
@@ -1,8 +1,30 @@
-import { describe, expect, it } from "@jest/globals";
+import fs from "node:fs/promises";
+import { describe, expect, it, jest } from "@jest/globals";
 import isDocumentedRoute from "./isDocumentedRoute";
 
+jest.mock("node:fs/promises");
+
 describe("isDocumentedRoute", () => {
-  it("should exist", () => {
-    expect(typeof isDocumentedRoute).toBe("function");
+  it("should return true if the file contains the target string", async () => {
+    const mockFileContent = "import { handler } from '@omer-x/next-openapi-route-handler';";
+    jest.spyOn(fs, "readFile").mockResolvedValue(mockFileContent);
+
+    const result = await isDocumentedRoute("some/path/to/file.ts");
+    expect(result).toBe(true);
+  });
+
+  it("should return false if the file does not contain the target string", async () => {
+    const mockFileContent = "import someOtherLibrary from 'another-package';";
+    jest.spyOn(fs, "readFile").mockResolvedValue(mockFileContent);
+
+    const result = await isDocumentedRoute("some/path/to/file.ts");
+    expect(result).toBe(false);
+  });
+
+  it("should return false if an error occurs while reading the file", async () => {
+    jest.spyOn(fs, "readFile").mockRejectedValue(new Error("File not found"));
+
+    const result = await isDocumentedRoute("non/existent/path.ts");
+    expect(result).toBe(false);
   });
 });

--- a/src/core/route.test.ts
+++ b/src/core/route.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "@jest/globals";
+import { type ZodType, z } from "zod";
 import { bundlePaths, createRouteRecord } from "./route";
 import type { OperationObject } from "@omer-x/openapi-types/operation";
-import type { ZodType } from "zod";
 
 describe("createRouteRecord", () => {
   it("should create a route record with the correct method, path, and apiData", () => {
@@ -99,6 +99,131 @@ describe("bundlePaths", () => {
           requestBody: undefined,
           responses: undefined,
           summary: "Create user",
+        },
+      },
+    });
+  });
+
+  it("should create references for the responses that are identical to pre-defined schemas", () => {
+    const source = [
+      {
+        method: "get",
+        path: "/user",
+        apiData: {
+          summary: "Get user",
+          responses: {
+            200: {
+              description: "Successful response",
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    properties: {
+                      name: {
+                        type: "string",
+                      },
+                      email: {
+                        type: "string",
+                        format: "email",
+                      },
+                    },
+                    required: ["name", "email"],
+                    additionalProperties: false,
+                  },
+                },
+              },
+            },
+          },
+        } as OperationObject,
+      },
+    ];
+    const storedSchemas: Record<string, ZodType> = {
+      UserDTO: z.object({
+        name: z.string(),
+        email: z.string().email(),
+      }),
+    };
+
+    const result = bundlePaths(source, storedSchemas);
+
+    expect(result).toStrictEqual({
+      "/user": {
+        get: {
+          parameters: undefined,
+          requestBody: undefined,
+          responses: {
+            200: {
+              content: {
+                "application/json": {
+                  schema: {
+                    $ref: "#/components/schemas/UserDTO",
+                  },
+                },
+              },
+              description: "Successful response",
+            },
+          },
+          summary: "Get user",
+        },
+      },
+    });
+  });
+
+  it("should handle the cases where schema is undefined or referenced already", () => {
+    const source = [
+      {
+        method: "get",
+        path: "/user",
+        apiData: {
+          summary: "Get user",
+          parameters: [
+            {
+              $ref: "#/components/parameters/QueryLimit",
+            },
+          ],
+          responses: {
+            200: {
+              description: "Successful response",
+              content: {
+                "application/json": {
+                  schema: undefined,
+                },
+              },
+            },
+            404: {
+              $ref: "#/components/responses/NotFound",
+            },
+          },
+        } as OperationObject,
+      },
+    ];
+    const storedSchemas: Record<string, ZodType> = {};
+
+    const result = bundlePaths(source, storedSchemas);
+
+    expect(result).toStrictEqual({
+      "/user": {
+        get: {
+          parameters: [
+            {
+              $ref: "#/components/parameters/QueryLimit",
+            },
+          ],
+          requestBody: undefined,
+          responses: {
+            200: {
+              content: {
+                "application/json": {
+                  schema: undefined,
+                },
+              },
+              description: "Successful response",
+            },
+            404: {
+              $ref: "#/components/responses/NotFound",
+            },
+          },
+          summary: "Get user",
         },
       },
     });

--- a/src/core/transpile.test.ts
+++ b/src/core/transpile.test.ts
@@ -44,4 +44,9 @@ describe("transpile", () => {
     const result = transpile("", "defineRoute", null);
     expect(result).not.toContain("require(\"zod\");");
   });
+
+  it("should inject a placeholder function for the middleware", () => {
+    const result = transpile("", "defineRoute", "myAwesomeMiddleware");
+    expect(result).toContain("var myAwesomeMiddleware = function (handler) { return handler; };");
+  });
 });

--- a/src/core/zod-to-openapi.test.ts
+++ b/src/core/zod-to-openapi.test.ts
@@ -67,4 +67,26 @@ describe("convertToOpenAPI", () => {
 
     expect(openAPISchema).toEqual(expectedSchema);
   });
+
+  it("should handle file type correctly in an object", () => {
+    const zodSchema = z.object({
+      file: z.instanceof(File),
+    });
+
+    const openAPISchema = convertToOpenAPI(zodSchema, false);
+
+    const expectedSchema: SchemaObject = {
+      type: "object",
+      properties: {
+        file: {
+          type: "string",
+          format: "binary",
+        },
+      },
+      required: ["file"],
+      additionalProperties: false,
+    };
+
+    expect(openAPISchema).toEqual(expectedSchema);
+  });
 });


### PR DESCRIPTION
Fixes #27 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced string replacement logic for dynamic injection of schema references into query and path parameters.
	- Added test cases to ensure correct handling of schema names in various contexts, including middleware and file types.

- **Bug Fixes**
	- Preserved original functionality while adding new behavior for handling `queryParams` and `pathParams`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->