### PR TITLE
fix: tighten isFile to reject partial schemas

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5699,7 +5699,8 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true,
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -5878,6 +5879,7 @@
       "deprecated": "Glob versions prior to v9 are no longer supported",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -5912,6 +5914,7 @@
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -5923,6 +5926,7 @@
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -6353,6 +6357,7 @@
       "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -11216,6 +11221,7 @@
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -11455,6 +11461,7 @@
       "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -12682,7 +12689,8 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true,
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/signale": {
       "version": "1.4.0",
@@ -14234,7 +14242,8 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/write-file-atomic": {
       "version": "4.0.2",
@@ -14242,6 +14251,7 @@
       "integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "imurmurhash": "^0.1.4",
         "signal-exit": "^3.0.7"

--- a/src/utils/zod-schema.test.ts
+++ b/src/utils/zod-schema.test.ts
@@ -13,4 +13,15 @@ describe("isFile", () => {
     expect(isFile(z.string())).toBe(false);
     expect(isFile(z.number())).toBe(false);
   });
+
+  it("should return false for an object schema without required fields", () => {
+    const objectSchema = z
+      .object({
+        name: z.string(),
+        age: z.number(),
+      })
+      .partial();
+    const result = isFile(objectSchema);
+    expect(result).toBe(false);
+  });
 });

--- a/src/utils/zod-schema.ts
+++ b/src/utils/zod-schema.ts
@@ -1,6 +1,13 @@
 import type { ZodType } from "zod";
 
 export function isFile(schema: ZodType<unknown>) {
-  const result = schema.safeParse(new File([], "nothing.txt"));
-  return result.success;
+  // Test that it accepts a File AND rejects a plain object
+  const file = new File([], "nothing.txt");
+  const plainObject = { name: "test", size: 0 };
+
+  const fileResult = schema.safeParse(file);
+  const objectResult = schema.safeParse(plainObject);
+
+  // Should accept File but reject plain object (if it's truly a File schema)
+  return fileResult.success && !objectResult.success;
 }


### PR DESCRIPTION
isFile was failing for the following schema

   ``` const objectSchema = z
      .object({
        name: z.string(),
        age: z.number(),
      })
      .partial();```
      
As the schema has no requirements it would successfully parse the file leading to false positives.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved file validation logic to ensure only actual File objects are recognized, preventing plain objects with similar properties from being misidentified as files.
- **Tests**
	- Added a new test case to confirm correct handling of schemas with only optional fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->