### PR TITLE
feat: sandboxed route eval, optimize option, and route group paths

### DIFF
--- a/src/core/generateOpenApiSpec.ts
+++ b/src/core/generateOpenApiSpec.ts
@@ -22,6 +22,7 @@ type GeneratorOptions = {
   security?: OpenApiDocument["security"],
   securitySchemes?: ComponentsObject["securitySchemes"],
   clearUnusedSchemas?: boolean,
+  optimize?: boolean,
 };
 
 export default async function generateOpenApiSpec(schemas: Record<string, ZodType>, {
@@ -34,6 +35,7 @@ export default async function generateOpenApiSpec(schemas: Record<string, ZodTyp
   security,
   securitySchemes,
   clearUnusedSchemas: clearUnusedSchemasOption = true,
+  optimize = true,
 }: GeneratorOptions = {}): Promise<Omit<OpenApiDocument, "components"> & Required<Pick<OpenApiDocument, "components">>> {
   const verifiedOptions = verifyOptions(includeOption, excludeOption);
   const appFolderPath = await findAppFolderPath();
@@ -79,5 +81,7 @@ export default async function generateOpenApiSpec(schemas: Record<string, ZodTyp
     tags: [],
   }));
 
-  return optimizeOpenApiSpec(spec) as Omit<OpenApiDocument, "components"> & Required<Pick<OpenApiDocument, "components">>;
+  type GeneratedSpec = Omit<OpenApiDocument, "components"> & Required<Pick<OpenApiDocument, "components">>;
+  if (!optimize) return spec as GeneratedSpec;
+  return optimizeOpenApiSpec(spec) as GeneratedSpec;
 }

--- a/src/core/getRoutePathName.ts
+++ b/src/core/getRoutePathName.ts
@@ -5,5 +5,6 @@ export default function getRoutePathName(filePath: string, rootPath: string): st
   return "/" + path.relative(rootPath, dirName)
     .replaceAll("[", "{")
     .replaceAll("]", "}")
-    .replaceAll("\\", "/");
+    .replaceAll("\\", "/")
+    .replaceAll(/\([^)]*\)\//g, "");
 }

--- a/src/core/getRoutePathName.ts
+++ b/src/core/getRoutePathName.ts
@@ -2,9 +2,14 @@ import path from "node:path";
 
 export default function getRoutePathName(filePath: string, rootPath: string): string {
   const dirName = path.dirname(filePath);
-  return "/" + path.relative(rootPath, dirName)
+  const relativePath = path.relative(rootPath, dirName)
     .replaceAll("[", "{")
     .replaceAll("]", "}")
-    .replaceAll("\\", "/")
-    .replaceAll(/\([^)]*\)\//g, "");
+    .replaceAll("\\", "/");
+
+  const segments = relativePath
+    .split("/")
+    .filter(segment => !(/^\([^)]*\)$/).test(segment));
+
+  return `/${segments.join("/")}`;
 }

--- a/src/core/next.test.ts
+++ b/src/core/next.test.ts
@@ -62,16 +62,15 @@ describe("getRouteExports", () => {
   });
 
   it("should handle errors during evaluation", async () => {
-    const error = new Error("Eval error");
-    const evalSpy = vi.spyOn(global, "eval").mockImplementation(() => {
-      throw error;
-    });
+    vi.spyOn(fs, "readFile").mockResolvedValueOnce([
+      "import defineRoute from \"@omer-x/next-openapi-route-handler\";",
+      "export const GET = (() => { throw new Error(\"Eval error\"); })();",
+    ].join("\n"));
     const consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => { /* do nothing */ });
 
-    await expect(getRouteExports(mockRoutePath, mockRouteDefinerName, mockSchemas)).rejects.toThrow(error);
+    await expect(getRouteExports(mockRoutePath, mockRouteDefinerName, mockSchemas)).rejects.toThrow("Eval error");
     expect(consoleLogSpy).toHaveBeenCalledWith(`An error occured while evaluating the route exports from "${mockRoutePath}"`);
 
-    evalSpy.mockRestore();
     consoleLogSpy.mockRestore();
   });
 });

--- a/src/core/next.ts
+++ b/src/core/next.ts
@@ -53,12 +53,24 @@ export async function getRouteExports(
   const middlewareName = detectMiddlewareName(rawCode);
   const code = transpile(true, rawCode, middlewareName, await getModuleTranspiler());
   const fixedCode = Object.keys(schemas).reduce(injectSchemas, code);
-  (global as Record<string, unknown>)[routeDefinerName] = defineRoute;
-  (global as Record<string, unknown>).z = z;
-  (global as Record<string, unknown>).schemas = schemas;
-  const result = safeEval(fixedCode, routePath);
-  delete (global as Record<string, unknown>).schemas;
-  delete (global as Record<string, unknown>)[routeDefinerName];
-  delete (global as Record<string, unknown>).z;
-  return result;
+  const globalScope = global as Record<string, unknown>;
+  const originalDescriptors = new Map<string, PropertyDescriptor | undefined>([
+    [routeDefinerName, Object.getOwnPropertyDescriptor(global, routeDefinerName)],
+    ["z", Object.getOwnPropertyDescriptor(global, "z")],
+    ["schemas", Object.getOwnPropertyDescriptor(global, "schemas")],
+  ]);
+  try {
+    globalScope[routeDefinerName] = defineRoute;
+    globalScope.z = z;
+    globalScope.schemas = schemas;
+    return safeEval(fixedCode, routePath);
+  } finally {
+    for (const [key, descriptor] of originalDescriptors) {
+      if (descriptor) {
+        Object.defineProperty(global, key, descriptor);
+      } else {
+        delete globalScope[key];
+      }
+    }
+  }
 }

--- a/src/core/next.ts
+++ b/src/core/next.ts
@@ -21,12 +21,13 @@ export async function findAppFolderPath(): Promise<string | null> {
   return null;
 }
 
-async function safeEval(code: string, routePath: string): Promise<Record<string, { apiData?: OperationObject } | undefined>> {
+function safeEval(code: string, routePath: string): Record<string, { apiData?: OperationObject } | undefined> {
   try {
-    if (typeof module !== "undefined" && typeof module.exports !== "undefined") {
-      return eval(code);
-    }
-    return await import(/* webpackIgnore: true */ `data:text/javascript,${encodeURIComponent(code)}`);
+    const sandboxExports: Record<string, unknown> = {};
+    const sandboxModule = { exports: sandboxExports };
+    const sandboxRequire = (): Record<string, never> => ({});
+    new Function("exports", "module", "require", code)(sandboxExports, sandboxModule, sandboxRequire);
+    return sandboxModule.exports as Record<string, { apiData?: OperationObject } | undefined>;
   } catch (error) {
     // eslint-disable-next-line no-console
     console.log(`An error occured while evaluating the route exports from "${routePath}"`);
@@ -50,13 +51,12 @@ export async function getRouteExports(
 ): Promise<Record<string, { apiData?: OperationObject } | undefined>> {
   const rawCode = await fs.readFile(routePath, "utf-8");
   const middlewareName = detectMiddlewareName(rawCode);
-  const isCommonJS = typeof module !== "undefined" && typeof module.exports !== "undefined";
-  const code = transpile(isCommonJS, rawCode, middlewareName, await getModuleTranspiler());
+  const code = transpile(true, rawCode, middlewareName, await getModuleTranspiler());
   const fixedCode = Object.keys(schemas).reduce(injectSchemas, code);
   (global as Record<string, unknown>)[routeDefinerName] = defineRoute;
   (global as Record<string, unknown>).z = z;
   (global as Record<string, unknown>).schemas = schemas;
-  const result = await safeEval(fixedCode, routePath);
+  const result = safeEval(fixedCode, routePath);
   delete (global as Record<string, unknown>).schemas;
   delete (global as Record<string, unknown>)[routeDefinerName];
   delete (global as Record<string, unknown>).z;


### PR DESCRIPTION
## Change list

- Replaced `eval`/data-URI import in `next.ts` with a `new Function` CommonJS sandbox.
- Added an `optimize` option to `generateOpenApiSpec`, defaulting to `true`.
- Stripped Next.js route groups (`(group)/`) from generated paths in `getRoutePathName`.

## Implementation Details

- `safeEval` is now synchronous — the sandbox needs no dynamic import, so the async plumbing in `getRouteExports` went away.
- Transpilation is hardcoded to CommonJS since the sandbox always supplies `exports`/`module`.
- The eval-error test now feeds a throwing route file instead of spying on `global.eval`, which the sandbox no longer touches.

## Tradeoffs

- `new Function` shares the realm with the build process; not isolation, just enough to run transpiled route modules predictably.
- `require` inside sandboxed code resolves to an empty object — routes importing runtime modules beyond the injected globals will fail.
- Route groups are stripped unconditionally; there is no opt-out for projects that want `(group)` segments in the emitted paths.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to generate OpenAPI specifications without optimization when needed; optimization remains enabled by default.
  * Improved route naming by removing parenthesized path segments from generated paths.

* **Bug Fixes**
  * Improved route evaluation reliability across environments.
  * Evaluation errors now surface with clearer error messages and continue to be logged appropriately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->