### PR TITLE
feat: dropped the typescript peer dependency in favor of sucrase

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@
 
 To use `@omer-x/next-openapi-json-generator`, you'll need the following dependencies in your Next.js project:
 
-- [TypeScript](https://www.typescriptlang.org/) >= v5
 - [Next.js](https://nextjs.org/) >= v13
 - [Zod](https://zod.dev/) >= v3
 - [Next OpenAPI Route Handler](https://www.npmjs.com/package/@omer-x/next-openapi-route-handler)

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "@omer-x/openapi-optimizer": "alpha",
         "@omer-x/package-metadata": "^1.0.2",
         "@omer/object": "npm:@jsr/omer__object@^1.1.0",
-        "minimatch": "^10.2.5"
+        "minimatch": "^10.2.5",
+        "sucrase": "^3.35.1"
       },
       "devDependencies": {
         "@omer-x/eslint-config": "^2.3.3",
@@ -21,12 +22,12 @@
         "eslint": "^9.39.2",
         "semantic-release": "^25.0.8",
         "tsdown": "^0.22.13",
+        "typescript": "^6",
         "vitest": "^4.1.10"
       },
       "peerDependencies": {
         "@omer-x/next-openapi-route-handler": "^2",
         "@omer-x/openapi-types": "^1",
-        "typescript": "^5 || ^6",
         "zod": "^4"
       }
     },
@@ -478,11 +479,20 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -492,14 +502,12 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -2362,7 +2370,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
       "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/argparse": {
@@ -2912,6 +2919,15 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/compare-func": {
       "version": "2.0.0",
@@ -4140,7 +4156,6 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -5853,7 +5868,6 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/load-json-file": {
@@ -6200,7 +6214,6 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
       "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "any-promise": "^1.0.0",
@@ -8262,7 +8275,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -8698,7 +8710,6 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
       "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -8715,6 +8726,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/pkg-conf": {
@@ -9920,6 +9940,28 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/sucrase": {
+      "version": "3.35.1",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
+      "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "commander": "^4.0.0",
+        "lines-and-columns": "^1.1.6",
+        "mz": "^2.7.0",
+        "pirates": "^4.0.1",
+        "tinyglobby": "^0.2.11",
+        "ts-interface-checker": "^0.1.9"
+      },
+      "bin": {
+        "sucrase": "bin/sucrase",
+        "sucrase-node": "bin/sucrase-node"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
     "node_modules/super-regex": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/super-regex/-/super-regex-1.1.0.tgz",
@@ -10053,7 +10095,6 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
       "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "any-promise": "^1.0.0"
@@ -10063,7 +10104,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
       "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "thenify": ">= 3.1.0 < 4"
@@ -10120,7 +10160,6 @@
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
       "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -10191,6 +10230,12 @@
       "peerDependencies": {
         "typescript": ">=4.8.4"
       }
+    },
+    "node_modules/ts-interface-checker": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "license": "Apache-2.0"
     },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",
@@ -10407,8 +10452,8 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -51,14 +51,14 @@
   "peerDependencies": {
     "@omer-x/next-openapi-route-handler": "^2",
     "@omer-x/openapi-types": "^1",
-    "typescript": "^5 || ^6",
     "zod": "^4"
   },
   "dependencies": {
     "@omer-x/openapi-optimizer": "alpha",
     "@omer-x/package-metadata": "^1.0.2",
     "@omer/object": "npm:@jsr/omer__object@^1.1.0",
-    "minimatch": "^10.2.5"
+    "minimatch": "^10.2.5",
+    "sucrase": "^3.35.1"
   },
   "devDependencies": {
     "@omer-x/eslint-config": "^2.3.3",
@@ -67,6 +67,7 @@
     "eslint": "^9.39.2",
     "semantic-release": "^25.0.8",
     "tsdown": "^0.22.13",
+    "typescript": "^6",
     "vitest": "^4.1.10"
   }
 }

--- a/src/core/next.ts
+++ b/src/core/next.ts
@@ -7,7 +7,6 @@ import injectSchemas from "./injectSchemas";
 import { detectMiddlewareName } from "./middleware";
 import { transpile } from "./transpile";
 import type { OperationObject } from "@omer-x/openapi-types/operation";
-import type { TranspileOptions, TranspileOutput } from "typescript";
 
 export async function findAppFolderPath(): Promise<string | null> {
   const inSrc = path.resolve(process.cwd(), "src", "app");
@@ -35,15 +34,6 @@ function safeEval(code: string, routePath: string): Record<string, { apiData?: O
   }
 }
 
-async function getModuleTranspiler(): Promise<(input: string, transpileOptions: TranspileOptions) => TranspileOutput> {
-  if (typeof require !== "undefined" && typeof exports !== "undefined") {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    return require(/* webpackIgnore: true */ "typescript").transpileModule;
-  }
-  const { transpileModule } = await import(/* webpackIgnore: true */ "typescript");
-  return transpileModule;
-}
-
 export async function getRouteExports(
   routePath: string,
   routeDefinerName: string,
@@ -51,7 +41,7 @@ export async function getRouteExports(
 ): Promise<Record<string, { apiData?: OperationObject } | undefined>> {
   const rawCode = await fs.readFile(routePath, "utf-8");
   const middlewareName = detectMiddlewareName(rawCode);
-  const code = transpile(true, rawCode, middlewareName, await getModuleTranspiler());
+  const code = transpile(rawCode, middlewareName);
   const fixedCode = Object.keys(schemas).reduce(injectSchemas, code);
   const globalScope = global as Record<string, unknown>;
   const originalDescriptors = new Map<string, PropertyDescriptor | undefined>([

--- a/src/core/transpile.test.ts
+++ b/src/core/transpile.test.ts
@@ -1,10 +1,9 @@
-import { transpileModule } from "typescript";
 import { describe, expect, it } from "vitest";
 import { transpile } from "./transpile";
 
 describe("transpile", () => {
   it("should inject export fixers", () => {
-    const result = transpile(true, "", null, transpileModule);
+    const result = transpile("", null);
     expect(result).toContain("exports.GET = void 0;");
     expect(result).toContain("exports.POST = void 0;");
     expect(result).toContain("exports.PUT = void 0;");
@@ -15,7 +14,16 @@ describe("transpile", () => {
   });
 
   it("should inject a placeholder function for the middleware", () => {
-    const result = transpile(true, "", "myAwesomeMiddleware", transpileModule);
+    const result = transpile("", "myAwesomeMiddleware");
     expect(result).toContain("const myAwesomeMiddleware = (handler) => handler;");
+  });
+
+  it("should strip types and emit CommonJS exports", () => {
+    const result = transpile([
+      "type Params = { id: string };",
+      "export const GET = (p: Params): string => p.id satisfies string;",
+    ].join("\n"), null);
+    expect(result).not.toContain("type Params");
+    expect(result).toContain("exports.GET =");
   });
 });

--- a/src/core/transpile.ts
+++ b/src/core/transpile.ts
@@ -1,5 +1,5 @@
+import { transform } from "sucrase";
 import removeImports from "~/utils/removeImports";
-import type ts from "typescript";
 
 function fixExportsInCommonJS(code: string): string {
   const validMethods = ["GET", "POST", "PUT", "PATCH", "DELETE"];
@@ -12,27 +12,14 @@ function injectMiddlewareFixer(middlewareName: string): string {
   return `const ${middlewareName} = (handler) => handler;`;
 }
 
-export function transpile(
-  isCommonJS: boolean,
-  rawCode: string,
-  middlewareName: string | null,
-  transpileModule: (input: string, transpileOptions: ts.TranspileOptions) => ts.TranspileOutput,
-): string {
+export function transpile(rawCode: string, middlewareName: string | null): string {
   const parts = [
     middlewareName ? injectMiddlewareFixer(middlewareName) : "",
     removeImports(rawCode),
   ];
-  const output = transpileModule(parts.join("\n"), {
-    compilerOptions: {
-      module: isCommonJS ? 3 : 99,
-      target: 99,
-      sourceMap: false,
-      inlineSourceMap: false,
-      inlineSources: false,
-    },
+  const { code } = transform(parts.join("\n"), {
+    transforms: ["typescript", "imports"],
+    disableESTransforms: true,
   });
-  if (isCommonJS) {
-    return fixExportsInCommonJS(output.outputText);
-  }
-  return output.outputText;
+  return fixExportsInCommonJS(code);
 }


### PR DESCRIPTION
## Change list

- Dropped `typescript` from `peerDependencies` — consumers no longer need it installed.
- Added `sucrase` as a runtime dependency to strip types from route files.
- Simplified `transpile()` to `transpile(rawCode, middlewareName)`, removing two parameters.
- Removed `getModuleTranspiler()` and its require/dynamic-import fallback from `next.ts`.
- Removed the TypeScript entry from README requirements; `typescript` moved to devDependencies.
- Added a test covering type stripping and CommonJS export emission.

## Implementation Details

- Sucrase runs only the `typescript` and `imports` transforms, with `disableESTransforms` so modern syntax passes through untouched.
- Output is now always CommonJS; the old `isCommonJS` branch was only ever called with `true`.
- Removing the injected transpiler also removes the `webpackIgnore` hints that kept bundlers from resolving `typescript`.

## Tradeoffs

- Sucrase strips types without typechecking; route files are never validated, only their exports read.
- Chose a bundled dependency over the consumer's TypeScript, adding install weight but removing peer-range risk.
- ESM output path deleted rather than kept behind a flag; restoring it means restoring the parameter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved route processing for TypeScript-based routes and CommonJS exports.
  * Added support for newer TypeScript development workflows.

* **Bug Fixes**
  * Improved handling of type annotations and module exports during route processing.

* **Documentation**
  * Updated project dependency documentation to reflect the current TypeScript requirements.

* **Tests**
  * Expanded coverage for type stripping and CommonJS export behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->